### PR TITLE
Remove wildcard from proxy url

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -17,7 +17,7 @@ new WebpackDevServer(webpack(webpackConfig), {
   lazy: false,
   stats: config.compiler_stats,
   proxy: {
-    '/api*': {
+    '/api': {
       target: 'http://localhost:8080',
       secure: false
     }


### PR DESCRIPTION
The proxy isn't working without this change, plus this matches
https://webpack.github.io/docs/webpack-dev-server.html#proxy
